### PR TITLE
build: Use external translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 *.kdev4
+src/translations/obconf-qt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,9 @@ else()
   message(STATUS "Building with Qt${Qt5Core_VERSION_STRING}")
 endif()
 
+#Note: no run-time dependency on liblxqt, just a build dependency for lxqt_translate_ts/desktop
+find_package(lxqt REQUIRED)
+
 find_package(PkgConfig)
 pkg_check_modules(GLIB REQUIRED
   glib-2.0

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,45 +57,26 @@ add_custom_command(
 
 # add translation for obconf-qt
 option (UPDATE_TRANSLATIONS "Update source translation translations/*.ts files" OFF)
-
-set(TRANSLATION_TEMPLATE "translations/obconf-qt.ts")
-file(GLOB TS_FILES translations/obconf-qt_*.ts)
-
-if(USE_QT4)
-  if (UPDATE_TRANSLATIONS)
-    qt4_create_translation(QMS_FILES
-      ${obconf-qt_SRCS}
-      ${obconf-qt_UI_H}
-      ${TRANSLATION_TEMPLATE}
-      OPTIONS -locations absolute)
-    qt4_create_translation(QMS_FILES
-      ${obconf-qt_SRCS}
-      ${obconf-qt_UI_H}
-      ${TS_FILES}
-      OPTIONS -locations absolute)
-  else (UPDATE_TRANSLATIONS)
-    qt4_add_translation(QM_FILES ${TS_FILES})
-  endif (UPDATE_TRANSLATIONS)
-else(USE_QT4) # use qt4
-  if (UPDATE_TRANSLATIONS)
-    qt5_create_translation(QMS_FILES
-      ${obconf-qt_SRCS}
-      ${obconf-qt_UI_H}
-      ${TRANSLATION_TEMPLATE}
-      OPTIONS -locations absolute)
-    qt5_create_translation(QM_FILES
-      ${obconf-qt_SRCS}
-      ${obconf-qt_UI_H}
-      ${TS_FILES}
-      OPTIONS -locations absolute)
-  else (UPDATE_TRANSLATIONS)
-    qt5_add_translation(QM_FILES ${TS_FILES})
-  endif (UPDATE_TRANSLATIONS)
-endif(USE_QT4)
-
-if(UPDATE_TRANSLATIONS)
-    add_custom_target(update_obconf-qt_translations ALL DEPENDS ${QMS})
-endif()
+include(LXQtTranslateTs)
+lxqt_translate_ts(QM_FILES
+  USE_QT4
+    ${USE_QT4}
+  UPDATE_TRANSLATIONS
+    ${UPDATE_TRANSLATIONS}
+  SOURCES
+    ${obconf-qt_SRCS}
+    ${obconf-qt_UI_H}
+  INSTALL_DIR
+    "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/translations"
+  PULL_TRANSLATIONS
+    ${PULL_TRANSLATIONS}
+  CLEAN_TRANSLATIONS
+    ${CLEAN_TRANSLATIONS}
+  TRANSLATIONS_REPO
+    ${TRANSLATIONS_REPO}
+  TRANSLATIONS_REFSPEC
+    ${TRANSLATIONS_REFSPEC}
+)
 
 # install a desktop entry file
 include(LXQtTranslateDesktop)
@@ -105,7 +86,6 @@ lxqt_translate_desktop(DESKTOP_FILES
 )
 install(FILES ${DESKTOP_FILES} DESTINATION share/applications)
 
-install(FILES ${QM_FILES} DESTINATION share/obconf-qt/translations)
 # prevent the generated files from being deleted during make clean
 set_directory_properties(PROPERTIES CLEAN_NO_CUSTOM true)
 


### PR DESCRIPTION
Also use the lxqt_translate_ts/lxqt_translate_desktop from the liblxqt.
But this is only a build dependency, no lxqt component is needed in
runtime.