### PR TITLE
Drops Qt5Core_VERSION_STRING

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ else()
   find_package(Qt5Widgets REQUIRED)
   find_package(Qt5X11Extras REQUIRED)
   find_package(Qt5LinguistTools REQUIRED QUIET)
-  message(STATUS "Building with Qt${Qt5Core_VERSION_STRING}")
+  message(STATUS "Building with Qt${Qt5Core_VERSION}")
 endif()
 
 find_package(lxqt-build-tools ${LXQTBT_MINIMUM_VERSION} REQUIRED)


### PR DESCRIPTION
Use Qt5Core_VERSION. Qt5Core_VERSION_STRING is a compatibility variable and
it was removed in Qt 5.9 release.