### PR TITLE
Fixes Qt4 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,14 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_AUTOMOC ON)
 
+
 if(USE_QT4)
+  set(USE_QT5 FALSE)
   find_package(Qt4 REQUIRED QtCore QtGui) # Qt
   include(${QT_USE_FILE})
   message(STATUS "Building with Qt${QTVERSION}")
 else()
+  set(USE_QT5 TRUE)
   cmake_minimum_required(VERSION 3.0.2 FATAL_ERROR)
   find_package(Qt5Widgets REQUIRED)
   find_package(Qt5X11Extras REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,8 +60,8 @@ add_custom_command(
 # add translation for obconf-qt
 option (UPDATE_TRANSLATIONS "Update source translation translations/*.ts files" OFF)
 lxqt_translate_ts(QM_FILES
-  USE_QT4
-    ${USE_QT4}
+  USE_QT5
+    ${USE_QT5}
   UPDATE_TRANSLATIONS
     ${UPDATE_TRANSLATIONS}
   SOURCES


### PR DESCRIPTION
Translation build was failing. We change the Qt default version in
LXQtTranslateTs but did not updated it's use accordingly.